### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Import-Module -Name Dns
 Resolve-DnsHost -Name 'example.com'
 ```
 
-On a successful lookup, returns a `DnsHost` object with the resolved host name, an alias (if any), and the list of IP addresses. If the host cannot be resolved, nothing is returned.
+On a successful lookup, returns a `DnsHost` object with the resolved hostname, an alias (if any), and the list of IP addresses. If the host cannot be resolved, nothing is returned.
 
 ### Example: Resolve only IPv4 addresses
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,43 @@
-# {{ NAME }}
+# Dns
 
-{{ DESCRIPTION }}
+Dns is a PowerShell module for resolving host names from PowerShell scripts and automation.
 
 ## Prerequisites
 
-This uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule/Process-PSModule) for building, testing and publishing the module.
+- PowerShell with `Microsoft.PowerShell.PSResourceGet` available for `Install-PSResource`.
+- The [PSModule framework](https://github.com/PSModule) is used for building, testing, and publishing the module.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-PSResource -Name {{ NAME }}
-Import-Module -Name {{ NAME }}
+Install-PSResource -Name Dns
+Import-Module -Name Dns
 ```
+
+## Commands
+
+- `Resolve-DnsHost` resolves a host name with `[System.Net.Dns]` and returns a structured `DnsHost` object.
 
 ## Usage
 
-Here is a list of example that are typical use cases for the module.
-
-### Example 1: Greet an entity
-
-Provide examples for typical commands that a user would like to do with the module.
+Resolve a host name:
 
 ```powershell
-Greet-Entity -Name 'World'
-Hello, World!
+Resolve-DnsHost -Name 'github.com'
 ```
 
-### Example 2
-
-Provide examples for typical commands that a user would like to do with the module.
+Resolve a host name for a specific address family:
 
 ```powershell
-Import-Module -Name PSModuleTemplate
+Resolve-DnsHost -Name 'github.com' -AddressFamily InterNetwork
 ```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
 
 ## Documentation
 
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+Command documentation is published at [psmodule.io/Dns](https://psmodule.io/Dns/).
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Import-Module -Name Dns
 Resolve-DnsHost -Name 'example.com'
 ```
 
-On a successful lookup, returns a `DnsHost` object with the resolved host name, any aliases, and the list of IP addresses. If the host cannot be resolved, nothing is returned.
+On a successful lookup, returns a `DnsHost` object with the resolved host name, an alias (if any), and the list of IP addresses. If the host cannot be resolved, nothing is returned.
 
 ### Example: Resolve only IPv4 addresses
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ Install-PSResource -Name Dns
 Import-Module -Name Dns
 ```
 
+## Usage
+
+### Example: Resolve a hostname to its IP addresses
+
+```powershell
+Resolve-DnsHost -Name 'example.com'
+```
+
+Returns a `DnsHost` object with the resolved host name, any aliases, and the list of IP addresses.
+
+### Example: Resolve only IPv4 addresses
+
+Use `-AddressFamily` to limit the resolution to a specific address family:
+
+```powershell
+Resolve-DnsHost -Name 'example.com' -AddressFamily InterNetwork
+```
+
 ## Documentation
 
 Documentation is published at [psmodule.io/Dns](https://psmodule.io/Dns/).
@@ -19,9 +37,5 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Dns
-Get-Help <CommandName> -Examples
+Get-Help -Name Resolve-DnsHost -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Import-Module -Name Dns
 Resolve-DnsHost -Name 'example.com'
 ```
 
-Returns a `DnsHost` object with the resolved host name, any aliases, and the list of IP addresses.
+On a successful lookup, returns a `DnsHost` object with the resolved host name, any aliases, and the list of IP addresses. If the host cannot be resolved, nothing is returned.
 
 ### Example: Resolve only IPv4 addresses
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Dns
 
-Dns is a PowerShell module for resolving host names from PowerShell scripts and automation.
-
-## Prerequisites
-
-- PowerShell with `Microsoft.PowerShell.PSResourceGet` available for `Install-PSResource`.
-- The [PSModule framework](https://github.com/PSModule) is used for building, testing, and publishing the module.
+Dns is a PowerShell module for managing DNS tasks.
 
 ## Installation
 
@@ -16,27 +11,16 @@ Install-PSResource -Name Dns
 Import-Module -Name Dns
 ```
 
-## Commands
-
-- `Resolve-DnsHost` resolves a host name with `[System.Net.Dns]` and returns a structured `DnsHost` object.
-
-## Usage
-
-Resolve a host name:
-
-```powershell
-Resolve-DnsHost -Name 'github.com'
-```
-
-Resolve a host name for a specific address family:
-
-```powershell
-Resolve-DnsHost -Name 'github.com' -AddressFamily InterNetwork
-```
-
 ## Documentation
 
-Command documentation is published at [psmodule.io/Dns](https://psmodule.io/Dns/).
+Documentation is published at [psmodule.io/Dns](https://psmodule.io/Dns/).
+
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module Dns
+Get-Help <CommandName> -Examples
+```
 
 ## Contributing
 


### PR DESCRIPTION
The `Dns` README is now a concise landing page in the standard PSModule format, so users can install the module and get a real, working example at a glance.

## What changed

- **Real `## Usage` example** — shows `Resolve-DnsHost -Name 'example.com'` (and an IPv4-only variant with `-AddressFamily`) instead of scaffold placeholders.
- **Fixed help snippet** — `Get-Help <CommandName> -Examples` is now `Get-Help -Name Resolve-DnsHost -Examples`, a real command.
- **Removed `## Contributing`** — the README is the published landing page; contribution info lives elsewhere.
- **Installation** uses `Install-PSResource` and links to [psmodule.io/Dns](https://psmodule.io/Dns/).

## Technical details

- Updates `README.md` only.
- Aligns with the standard module landing-page format (`# Module` → overview → Installation → Usage → Documentation).